### PR TITLE
Compare registries and only migrate remaining versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset
+charset = utf-8
+
+# Indentation
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ migrate(moduleName, from, to, options)
 
 ## What it does
 
-1. Fetches all versions as tarballs from old registry
+1. Fetches all versions (or just those not already migrated) as tarballs from old registry
 2. Extracts & updates `package.json`: the `publishConfig.registry` field to the new registry url
 3. Publishes each version to the new registry
 4. Cleans up after itself
@@ -35,3 +35,8 @@ migrate(moduleName, from, to, options)
 
 - The dates of every version published will be reset to the date and time you run this script
 - The migrating user will be added as maintainer
+
+## Changelog
+
+- v1.2.0 - Work with scoped packages
+- v1.3.0 - Compare both registries and migrate only the remaining versions not in the new registry

--- a/npm-migrate.js
+++ b/npm-migrate.js
@@ -22,7 +22,7 @@ module.exports = function (moduleName, oldRegistry, newRegistry, options = { deb
     let curried_publishSeries = curry(publishSeries)
     curried_publishSeries = curried_publishSeries(newRegistry)
 
-    return getVersionList(moduleName, oldRegistry)
+    return getVersionList(moduleName, oldRegistry, newRegistry)
         .then(curried_getTarballs)
         .then(unpack)
         .then(curried_updatePackage)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-migrate",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Migrate all versions of a selected package from a registry to another one",
   "main": "npm-migrate.js",
   "scripts": {


### PR DESCRIPTION
Compares what versions are in each registry and only migrates remaining versions.

Closes #2.
