### PR TITLE
improvement: prevent silent failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ migrate(moduleName, from, to, options)
 - The dates of every version published will be reset to the date and time you run this script
 - The migrating user will be added as maintainer
 
+## Troubleshooting
+* `failed to query new registry for existing versions`:  
+  Ensure you have access to new repository and have `always-auth=true` set either in your global .npmrc or a local one.
+
 ## Changelog
 
 - v1.2.0 - Work with scoped packages

--- a/npm_utils.js
+++ b/npm_utils.js
@@ -59,6 +59,7 @@ function getRemainingVersions (moduleName, oldRegistry, newRegistry, oldRegistry
         npm.commands.info([moduleName], (err, data) => {
 
             if (err) {
+                console.warn('failed to query new registry for existing versions, migrating all', err);
                 return resolve(oldRegistryVersions);
             }
         


### PR DESCRIPTION
Without `always-auth=true`, querying already migrated versions fails silently. This PR prints a warning and adds troubleshooting advice in the README.