### PR TITLE
Update npm_utils.js

### DIFF
--- a/npm_utils.js
+++ b/npm_utils.js
@@ -58,23 +58,23 @@ function getRemainingVersions (moduleName, oldRegistry, newRegistry, oldRegistry
         npm.config.set('registry', newRegistry);
         npm.commands.info([moduleName], (err, data) => {
 
-            if (err) {
+            if (err || !Object.keys(data).length) {
                 return resolve(oldRegistryVersions);
             }
-        
+            
             const latest = Object.keys(data)[0];
             const newRegistryVersions = data[latest].versions;
             console.log('New Registry Versions', newRegistryVersions);
 
-            remainingVersions = oldRegistryVersions.filter((v) => !newRegistryVersions.includes(v));
+            const remainingVersions = oldRegistryVersions.filter((v) => !newRegistryVersions.includes(v));
+
             if (!remainingVersions.length) {
                 console.log('No more versions of this package to migrate');
             } else {
                 console.log('Remaining Versions to Migrate', remainingVersions);
             }
-
-            resolve(remainingVersions);
-
+                
+            resolve(remainingVersions);       
         });
         npm.config.set('registry', oldRegistry);
 


### PR DESCRIPTION
Check if there is data in new registry. When no data, value is `{}` and a error is throw at 
```
const latest = Object.keys(data)[0];
const newRegistryVersions = data[latest].versions;
```